### PR TITLE
Fix path for setup.py, add missing _ for whl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ Simple wrapper to leverage DataRobot Codegen Models in Python.  This works for t
 * python >= 3.7
 * valid datarobot codegen jar
 
-You can run 
+To create the whl, run `setup.py`
 ```
-python3 ./codegen_wrapper/setup.py bdist_wheel 
-pip3 install -U ./codegen_wrapper/dist/datarobot_codegen_wrapper*.whl
+cd codegen_wrapper
+python3 ./setup.py bdist_wheel 
+```
+
+After you have the whl, install with pip:
+```
+pip3 install -U dist/datarobot_codegen_wrapper*.whl
 ```
 
 If you would like to build locally, you will need

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Simple wrapper to leverage DataRobot Codegen Models in Python.  This works for t
 
 You can run 
 ```
-python3 ./codegen_wrapper/setup.py bdist wheel 
+python3 ./codegen_wrapper/setup.py bdist_wheel 
 pip3 install -U ./codegen_wrapper/dist/datarobot_codegen_wrapper*.whl
 ```
 

--- a/codegen_wrapper/setup.py
+++ b/codegen_wrapper/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("../README.md", "r") as fh:
+with open("./README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(

--- a/codegen_wrapper/setup.py
+++ b/codegen_wrapper/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("./README.md", "r") as fh:
+with open("../README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Hey Tim! Here's a super minor PR :) I just changed the README for the setup installations. Otherwise, in which dir you are when you run the commands could make the `setup.py` to fail because of the relative path references. 
I verified the fixes with a clean install but hope I didn't overlook anything.